### PR TITLE
Reduce overview h1 font size by 1px

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -783,7 +783,7 @@ a.more{
 
 .overview h1 {
 	color: #24b9ff;
-	font-size: 24px;
+	font-size: 23px;
 	font-family: 'Museo300Regular';
     margin-top: 1em;
     margin-bottom: 0.25em;


### PR DESCRIPTION
On Chrome in Linux, it was too wide with 'Zend Framework X' in the left
bar, causing it to wrap.

Before:

![](http://evan.pro/caps/754372.png)

After:

![](http://evan.pro/caps/ca69c2.png)
