### PR TITLE
Update IRC channel information

### DIFF
--- a/module/PageController/view/page-controller/contact/irc.phtml
+++ b/module/PageController/view/page-controller/contact/irc.phtml
@@ -23,12 +23,6 @@ $this->headTitle()->prepend('IRC');
         <dd>For general usage questions and problems.</dd>
 
         <dt>#zftalk.dev</dt>
-        <dd>For discussion of ZF versions 1.X development.</dd>
-
-        <dt>#zftalk.2</dt>
-        <dd>For discussion of ZF versions 2.X development.</dd>
-
-        <dt>#zftalk.community</dt>
-        <dd>For general discussion, not always limited to development topics.</dd>
+        <dd>For discussion of ZF development.</dd>
     </dl>
 </section>

--- a/module/PageController/view/page-controller/participate/contributor-guide.phtml
+++ b/module/PageController/view/page-controller/participate/contributor-guide.phtml
@@ -93,11 +93,10 @@ $headTitle->prepend('Contributor Guide');
 
     <ul>
         <li>
-            <a name="irc" href="/irc-info">In IRC:</a> on freenode, chat rooms:
+            <a name="irc" href="/irc">In IRC:</a> on freenode, chat rooms:
             <ul>
-                <li><a href="irc://irc.freenode.net/zftalk.2">#zftalk.2</a></li>
                 <li><a href="irc://irc.freenode.net/zftalk">#zftalk</a></li>
-                <li><a href="irc://irc.freenode.net/zftalk.community">#zftalk.community</a></li>
+                <li><a href="irc://irc.freenode.net/zftalk.dev">#zftalk.dev</a></li>
             </ul>
 
         </li>


### PR DESCRIPTION
Remove #zftalk.2 and #zftalk-community from the website, as they are obsolete now.
