### PR TITLE
URGENT: Fixed links + redirect for old ZF1 docs URL

### DIFF
--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -133,7 +133,7 @@ echo $this->doctype();
           <div class="links">
             <h4>Learn</h4>
             <ul>
-              <li><a href="<?php echo $this->manualUrl('user-guide/index.html') ?>">User Guide</a></li>
+              <li><a href="<?php echo $this->manualUrl('user-guide/overview.html') ?>">User Guide</a></li>
               <li><a href="<?php echo $this->manualUrl('index.html') ?>">Reference Guide</a></li>
               <li><a href="<?php echo $this->url('docs/api') ?>">APIs</a></li>
 <!--              <li><a href="">Webinars</a></li>-->

--- a/module/Manual/config/module.config.php
+++ b/module/Manual/config/module.config.php
@@ -8,7 +8,7 @@ return array(
                     'route' => '/manual/:version/:lang/:page',
                     'constraints' => array(
                         'lang'    => '[a-z]{2}',
-                        'version' => '[0-9\.a-z]+',
+                        'version' => '[0-9\.]+',
                         'page'    => '.+'
                     ),
                     'defaults' => array(

--- a/rewrites.php
+++ b/rewrites.php
@@ -9,7 +9,8 @@ $rewriteTable = array(
 
 $rewriteRegexes = array(
     '#^/zf2/blog/entry/(?P<id>[^/]+)#' => '/blog/%id%.html',
-    '#^/manual(/(?P<version>\d+.\d+)(/(?P<lang>[a-z]{2}(_[a-zA-Z]+)?)(/)?)?)?$#' => function ($uri, array $matches) {
+    '#^/manual/(?P<lang>[a-z]{2}(_[a-zA-Z]+)?)(?P<page>.*)$#' => '/manual/1.12/%lang%%page%',
+    '#^/manual(/(?P<version>\d+\.\d+)(/(?P<lang>[a-z]{2}(_[a-zA-Z]+)?)(/)?)?)?$#' => function ($uri, array $matches) {
         $lang    = isset($matches['lang'])    ? $matches['lang']    : 'en';
         $version = isset($matches['version']) ? $matches['version'] : '2.0';
         if ('1.' === substr($matches['version'], 0, 2)) {
@@ -57,7 +58,6 @@ $test = function () use ($rewriteTable, $rewriteRegexes, $rewrite) {
             $rewrite($rewriteUri);
             return;
         }
-
         $replacements = array();
         foreach ($matches as $key => $value) {
             if (is_int($key) || is_numeric($key)) {


### PR DESCRIPTION
Fixed the link User Guide in the footer.
Added the redirect rule to support the old URL schema of ZF1 documentation.
For instance, the URL of Zend_Mail was: framework.zend.com/manual/en/zend.mail.html
and now is: framework.zend.com/manual/1.12/en/zend.mail.html
All the Google results regarding the ZF1 manual are broken without this redirect!!!
