### PR TITLE
correcting the wording in the sidebar s/Reference's/Reference/

### DIFF
--- a/module/Manual/view/manual/page-controller/learn/sidebar.phtml
+++ b/module/Manual/view/manual/page-controller/learn/sidebar.phtml
@@ -8,14 +8,14 @@
 <h1>Zend Framework 2</h1>
 <ul>
     <li><a href="/manual/2.0/en/user-guide/overview.html">Getting started</a></li>
-    <li><a href="/manual/2.0/en/index.html">Reference's Guide</a></li>
+    <li><a href="/manual/2.0/en/index.html">Reference Guide</a></li>
     <li><a href="/docs/api">API</a></li>
 </ul>
 
 <h1>Zend Framework 1</h1>
 <ul>
     <li><a href="/manual/1.12/en/learning.quickstart.html">Getting started</a></li>
-    <li><a href="/manual/1.12/en/manual.html">Reference's Guide</a></li>
+    <li><a href="/manual/1.12/en/manual.html">Reference Guide</a></li>
     <li><a href="/docs/api#zf1">API</a></li>
 </ul>
 


### PR DESCRIPTION
The sidebar should read Reference Guide rather than Reference's Guide in both menu items.
