### PR TITLE
Links for direct PDF and EPUB documentation download

### DIFF
--- a/module/Application/view/application/index/index.phtml
+++ b/module/Application/view/application/index/index.phtml
@@ -91,8 +91,6 @@ $this->inlineScript()->appendFile($this->basePath() . '/js/jScrollPane.js')
               <h4><a href="<?php echo $this->manualUrl('index.html', 'en', '2.0') ?>">Read the ZF2 reference guide</a></h4>
               <h4><a href="<?php echo $this->manualUrl('learning.quickstart.html', 'en', '1.12') ?>">Get started with ZF1</a></h4>
               <h4><a href="<?php echo $this->manualUrl('manual.html', 'en', '1.12') ?>">Read the ZF1 reference guide</a></h4>
-              <h4><a href="https://media.readthedocs.org/pdf/zf2/latest/zf2.pdf">Download latest PDF</a></h4>
-              <h4><a href="https://media.readthedocs.org/epub/zf2/latest/zf2.epub">Download latest EPUB</a></h4>
             </div>
 
             <div id="get-involved-content">

--- a/module/Downloads/view/downloads/downloads/index.phtml
+++ b/module/Downloads/view/downloads/downloads/index.phtml
@@ -28,6 +28,20 @@ $this->headTitle()->prepend('Downloads');
         (.tar.gz) formats.
     </p>
 
+    <h2>Download ZF2 documentation files</h2>
+
+    <p>
+        Want to read documentation with your portable devices?
+    </p>
+    
+    <p>
+        <a href="https://media.readthedocs.org/pdf/zf2/latest/zf2.pdf">Download latest PDF</a></h4>
+    </p>
+    
+    <p>
+        <a href="https://media.readthedocs.org/epub/zf2/latest/zf2.epub">Download latest EPUB</a></h4>
+    </p>
+    
     <h2>Try ZF2 on phpcloud</h2>
 
     <p>


### PR DESCRIPTION
Since there is no mentioning on the zf-web about generated documentation PDF and EPUB files, this really should be the case for the new people wanting to use docs on their offline devices.
