### PR TITLE
s/reference's/reference/ typo in /api sidebar

### DIFF
--- a/module/Manual/view/manual/page-controller/api/sidebar.phtml
+++ b/module/Manual/view/manual/page-controller/api/sidebar.phtml
@@ -2,12 +2,12 @@
 <h1>Zend Framework 2</h1>
 <ul>
     <li><a href="/manual/2.0/en/user-guide/overview.html">Getting started</a></li>
-    <li><a href="/manual/2.0/en/index.html">Reference's Guide</a></li>
+    <li><a href="/manual/2.0/en/index.html">Reference Guide</a></li>
 </ul>
 <h1>Zend Framework 1</h1>
 <ul>
     <li><a href="/manual/1.12/en/learning.quickstart.html">Getting started</a></li>
-    <li><a href="/manual/1.12/en/manual.html">Reference's Guide</a></li>
+    <li><a href="/manual/1.12/en/manual.html">Reference Guide</a></li>
 </ul>
 <h1>More info</h1>
 <ul>


### PR DESCRIPTION
This typo also appears at /api on the docs site where, this corrects it.
