### PR TITLE
 fix Call to undefined method Zend\Http\Response::getStatusMessage() in ConsoleController and enhance Console - github fetch contributors, contributors : contribute to code and/or documentation : "merge" of zf2 and/or zf2-documentation contributors

### DIFF
--- a/module/Application/src/Application/Controller/ConsoleController.php
+++ b/module/Application/src/Application/Controller/ConsoleController.php
@@ -72,7 +72,7 @@ class ConsoleController extends AbstractActionController
         $response = $client->send();
         if (!$response->isSuccess()) {
             // report failure
-            $message = $response->getStatusCode() . ': ' . $response->getStatusMessage();
+            $message = $response->getStatusCode() . ': ' . $response->getReasonPhrase();
             $this->reportError($width, 0, $message);
             return;
         }
@@ -84,7 +84,7 @@ class ConsoleController extends AbstractActionController
         $response = $client->send();
         if (!$response->isSuccess()) {
             // report failure
-            $message = $response->getStatusCode() . ': ' . $response->getStatusMessage();
+            $message = $response->getStatusCode() . ': ' . $response->getReasonPhrase();
             $this->reportError($width, 0, $message);
             return;
         }
@@ -101,7 +101,7 @@ class ConsoleController extends AbstractActionController
             $response = $client->send();
             if (!$response->isSuccess()) {
                 // report failure
-                $error = $response->getStatusCode() . ': ' . $response->getStatusMessage();
+                $error = $response->getStatusCode() . ': ' . $response->getReasonPhrase();
                 $this->reportError($width, strlen($message), $error);
             }
             $body     = $response->getBody();


### PR DESCRIPTION
1. fix call to undefined method Zend\Http\Response::getStatusMessage().
2. It based on statement : <i>"Zend Framework's contributors have provided guidance, code, documentation, tests, and support for other community members since the inception of the project."</i> in http://framework.zend.com/participate page in <b><i>contributors<i></b> section.

so, it should require the <i>merge</i> data from :
1. https://api.github.com/repos/zendframework/zf2/contributors and
2. https://api.github.com/repos/zendframework/zf2-documentation/contributors
