### PR TITLE
ZF2 Docs Highlight box fix

### DIFF
--- a/public/css/manual/2/pygments.css
+++ b/public/css/manual/2/pygments.css
@@ -2,7 +2,6 @@
 .highlight, .highlight-txt  { 
     background: #eeffcc; 
     width: 590px;
-    height: 100%;
     overflow: auto;
 }
 .highlight .c { color: #408090; font-style: italic } /* Comment */


### PR DESCRIPTION
The Highlight box on the zf2 site will not flow into the text below it any more
- removed a height: 100% CSS property. It is not needed
