### PR TITLE
Manual: Code block CSS fix for Safari, Chrome

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1257,11 +1257,11 @@ dd {
 }
 
 .manual div.highlight, .manual div.highlight-txt {
-    -moz-border-radius: 15px;
-    -webkit-border-radius: 20px;
+    -webkit-border-radius: 10px;
+    border-radius: 10px;
     border: 1px solid #24b9ff;
-    margin-top: 1em;
-    margin-bottom: 1em;
+    margin-top: 0;
+    margin-bottom: 0;
     padding: 0.5em;
 }
 


### PR DESCRIPTION
Safari/Chrome CSS fix for code block margins and border radius. 

Safari screenshot of the issue:
![CSS issue](http://grab.by/hhyi)
