### PR TITLE
[#80] Fix for docs link and version select list

### DIFF
--- a/config/autoload/module.manual.global.php
+++ b/config/autoload/module.manual.global.php
@@ -29,6 +29,9 @@ foreach ($zf2versions as $version) {
         $paths[$version][$lang] = sprintf($zf2ManualPath, $version, $lang);
     }
 }
+
+krsort($paths);
+
 return array(
     'zf_document_path' => $paths,
 );

--- a/module/Manual/config/module.config.php
+++ b/module/Manual/config/module.config.php
@@ -3,7 +3,7 @@ return array(
     'router' => array(
         'routes' => array(
             'manual' => array(
-                'type' => 'Zend\Mvc\Router\Http\Segment',
+                'type' => 'Segment',
                 'options' => array(
                     'route' => '/manual/:version/:lang/:page',
                     'constraints' => array(
@@ -15,7 +15,7 @@ return array(
                         'controller' => 'Manual/Controller/Page',
                         'action'     => 'manual',
                         'lang'       => 'en',
-                        'version'    => '2.0',
+                        'version'    => '2.1',
                         'page'       => 'index.html',
                     ),
                 ),
@@ -54,7 +54,7 @@ return array(
                 ),
             ),
             'docs' => array(
-                'type' => 'Zend\Mvc\Router\Http\Segment',
+                'type' => 'Segment',
                 'options' => array(
                     'route' => '/docs[/]',
                     'defaults' => array(
@@ -65,7 +65,7 @@ return array(
                 'may_terminate' => true,
                 'child_routes'  => array(
                     'api' => array(
-                        'type' => 'Zend\Mvc\Router\Http\Segment',
+                        'type' => 'Segment',
                         'options' => array(
                             'route'    => 'api[/]',
                             'defaults' => array(

--- a/module/Manual/src/Manual/Controller/PageController.php
+++ b/module/Manual/src/Manual/Controller/PageController.php
@@ -15,6 +15,7 @@ class PageController extends AbstractActionController
      * @var array 
      */
     protected $params;
+
     /**
      * @var ResolverInterface
      */
@@ -152,7 +153,7 @@ class PageController extends AbstractActionController
                      '1.0.3',
                  ),
                  2 => array(
-                     '2.1.1',
+                     '2.1.3',
                      '2.0.7',
                  ),
             )

--- a/module/Manual/view/manual/page-controller/learn/sidebar.phtml
+++ b/module/Manual/view/manual/page-controller/learn/sidebar.phtml
@@ -18,10 +18,10 @@ $this->placeholder('sidebar')->captureStart(); ?>
 <h1>Zend Framework 2</h1>
 <ul>
     <li>
-        <a href="<?php echo $this->basePath('manual/2.0/en/user-guide/overview.html') ?>">Getting started</a>
+        <a href="<?php echo $this->basePath('manual/2.1/en/user-guide/overview.html') ?>">Getting started</a>
     </li>
     <li>
-        <a href="<?php echo $this->basePath('manual/2.0/en/index.html') ?>">Reference Guide</a>
+        <a href="<?php echo $this->basePath('manual/2.1/en/index.html') ?>">Reference Guide</a>
     </li>
     <li<?php echo ($this->active == 'api' ? ' class="active"' : '') ?>>
         <a href="<?php echo $this->basePath('docs/api#zf2') ?>">API</a>


### PR DESCRIPTION
Only a quick fix. Better solution without hardcoded version number in view scripts and sidebar will come later.

See: #80
