### PR TITLE
Keep the user on the same manual page if they change ZF version

### DIFF
--- a/module/Manual/config/module.config.php
+++ b/module/Manual/config/module.config.php
@@ -24,6 +24,16 @@ return array(
                     ),
                 ),
             ),
+            'manual-version-switch' => array(
+                'type' => 'Literal',
+                'options' => array(
+                    'route' => '/manual-version-switch',
+                    'defaults' => array(
+                        'controller' => 'Manual/Controller/Page',
+                        'action'     => 'version-switch',
+                    )
+                )
+            ),
             'learn' => array(
                 'type' => 'Segment',
                 'options' => array(

--- a/module/Manual/view/manual/page-controller/manual.phtml
+++ b/module/Manual/view/manual/page-controller/manual.phtml
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $this->layout()->active = 'learn';
 $this->layout()->bodyId = 'manual';
 
@@ -12,6 +12,8 @@ $this->render('manual/page-controller/manual/sidebar', array(
     'version'      => $this->version,
     'contentList'  => $contentList,
     'currentPage'  => $currentPage,
+    'lang'         => $this->lang,
+    'page'         => $this->page
 ));
 ?>
 

--- a/module/Manual/view/manual/page-controller/manual/sidebar.phtml
+++ b/module/Manual/view/manual/page-controller/manual/sidebar.phtml
@@ -11,11 +11,16 @@
 </div>
 
 <?php
-$basePath = $this->basePath('/manual/');
+$versionSwitchParams = array(
+    'old' => $this->version,
+    'lang' => $this->lang,
+    'page' => $this->page
+);
+$basePath = $this->url('manual-version-switch', array(), array('query' => $versionSwitchParams));
 $this->inlineScript()->captureStart();
 echo <<<JS
     $('#select-version select').change(function(){
-        location.href = '$basePath' + $(this).val() + '/en/';
+        location.href = '$basePath&new=' + $(this).val();
     });
 JS;
 $this->inlineScript()->captureEnd();


### PR DESCRIPTION
I've modified the "Select a version" dropdown on the manual pages so that if a user selects a different version, the site will redirect them to that version of the docs but attempt to keep them on the same manual page they were on. If the equivalent page doesn't exist it will just redirect them to the index page for that version's docs (which is what the site always did before).
