### PR TITLE
[#142] Proper fix

### DIFF
--- a/module/Downloads/src/Downloads/Controller/DownloadsController.php
+++ b/module/Downloads/src/Downloads/Controller/DownloadsController.php
@@ -24,6 +24,9 @@ class DownloadsController extends AbstractActionController
      */
     public function indexAction()
     {
+        return array(
+            'releases' => $this->releases,
+        );
     }
 
     /**

--- a/module/Downloads/view/downloads/downloads/index.phtml
+++ b/module/Downloads/view/downloads/downloads/index.phtml
@@ -2,6 +2,8 @@
 $this->render('downloads/downloads/sidebar', array('active' => 'overview'));
 
 $this->headTitle()->prepend('Downloads');
+
+$zf2Version = $this->releases->getCurrentStableVersion(2);
 ?>
 <h1>Downloads</h1>
 
@@ -35,8 +37,8 @@ $this->headTitle()->prepend('Downloads');
 </p>
 
 <ul class="button-group">
-    <li><a href="https://packages.zendframework.com/releases/ZendFramework-1.12.7/ZendFramework-1.12.7-manual-en.pdf" class="button">Download latest PDF</a></li>
-    <li><a href="https://packages.zendframework.com/releases/ZendFramework-1.12.7/ZendFramework-1.12.7-manual-en.epub" class="button">Download latest EPUB</a></li>
+    <li><a href="http://packages.zendframework.com/releases/ZendFramework-<?php echo $zf2Version ?>/ZendFramework-<?php echo $zf2Version ?>-manual-en.pdf">PDF</a></li>
+    <li><a href="http://packages.zendframework.com/releases/ZendFramework-<?php echo $zf2Version ?>/ZendFramework-<?php echo $zf2Version ?>-manual-en.epub">EPUB</a></li>
 </ul>
 
 <h2>Use Composer or Pyrus</h2>


### PR DESCRIPTION
This provides a proper fix for #142, and ensures links do not have to be updated manually in the future.
- Use release information to build epub/pdf links dynamically on download
  landing page.
