### PR TITLE
Fix the 1.12.8 release announcement

### DIFF
--- a/data/posts/2014-08-26-1.12.8-Released.php
+++ b/data/posts/2014-08-26-1.12.8-Released.php
@@ -38,6 +38,11 @@ $extended =<<<'EOC'
 <h2>Notable Changes</h2>
 
 <ul>
+    <li><a href="https://github.com/zendframework/zf1/pull/418">#418</a> Improved regex for
+        SQL group, order, from statement. This is an improvement of the Security Advisory
+        <a href="http://framework.zend.com/security/advisory/ZF2014-04">ZF2014-04</a>,
+        to prevent potential SQL injection. This PR that can be a potential BC break for
+        complex SQL code. See below for more information.</li>
     <li><a href="https://github.com/zendframework/zf1/pull/360">#360</a> updates Zend_Locale
         to use <a href="http://cldr.unicode.org">CLDR</a> version 25.</li>
     <li><a href="https://github.com/zendframework/zf1/pull/98">#98</a> allows editing and
@@ -47,7 +52,7 @@ $extended =<<<'EOC'
         <kbd>Zend_Pdf::resetJavaScript()</kbd>.</li>
     <li><a href="https://github.com/zendframework/zf1/pull/414">#414</a> adds the
         <kbd>Microsoft_Console</kbd> component from the Windows Azure SDK for PHP into
-        the <kbd>Zend_Service_Console</kbd> component, ensuring that WindowsAzure 
+        the <kbd>Zend_Service_Console</kbd> component, ensuring that WindowsAzure
         command line functionality included in the framework can now work.</li>
     <li><a href="https://github.com/zendframework/zf1/pull/385">#385</a> adds support for
         DateTime fractional seconds under PHP 5.6+.</li>
@@ -61,6 +66,14 @@ $extended =<<<'EOC'
 </ul>
 
 <p>See <a href="http://framework.zend.com/changelog/1.12.8">the changelog</a> for full details.</p>
+
+<h2>Potential BC break</h2>
+
+<p>The PR <a href="https://github.com/zendframework/zf1/pull/418">#418</a> can introduces
+potential BC break in presence of complex SQL statements (for instance using SQL sub-functions).</p>
+<p>To fix this you can use <strong>Zend_Db_Expr()</strong> in the group(), order() or from()
+functions, if your SQL code doesn't work after the upgrade to ZF 1.12.8.</p>
+
 
 <h2>Thank You!</h2>
 


### PR DESCRIPTION
As suggested by @ramsey [here](http://framework.zend.com/blog/zend-framework-1-12-8-released.html#comment-1572198749), I added the PR [zf1#418](https://github.com/zendframework/zf1/pull/418) to the Notable Changes section. Moreover, I added a new section: Potential BC break, to show how to fix SQL code using the `Zend_Db_Expr` function.
