### PR TITLE
Added the scripts for extract pages in Markdown

### DIFF
--- a/bin/compile.php
+++ b/bin/compile.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Compile the zf-web site in static HTML files
+ *
+ * Note: this is an experimental script, use at your own risk!
+ *
+ * @author Enrico Zimuel 
+ */
+chdir(dirname(__DIR__ . '/../public'));
+
+use Zend\ServiceManager\ServiceManager;
+use Zend\Mvc\Service\ServiceManagerConfig;
+use Zend\Mvc\Application;
+use Zend\Http\Request;
+
+include 'vendor/autoload.php';
+
+$configuration = include 'config/application.config.php';
+
+$app    = Application::init($configuration);
+$config = $app->getConfig();
+$urls   = filterUrls(getUrlFromRoutes($config['router']['routes']));
+
+// Dispatch all the URLs with the ZF2 Application
+foreach ($urls as $url) {
+    printf("Dispatching \"%s\"...", $url);
+    $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : [];
+    $serviceManager = new ServiceManager(new ServiceManagerConfig($smConfig));
+
+    $request = new Request();
+    $request->setMethod('GET');
+    $request->setUri($url);
+
+    var_dump((string) $request);
+    $serviceManager->setService('ApplicationConfig', $configuration);
+    $serviceManager->get('ModuleManager')->loadModules();
+
+    $serviceManager->setAllowOverride(true);
+    $serviceManager->setService('Request', $request);
+    $serviceManager->setAllowOverride(false);
+
+    $listeners = isset($configuration['listeners']) ? $configuration['listeners'] : array();
+
+    $app = new Application($configuration, $serviceManager);
+    $app->bootstrap($listeners)->run();
+    printf("done\n");
+
+    $response = $app->getResponse();
+    if ($response->getStatusCode() == 200) {
+        printf("Rendering \"%s\" to file...", $url);
+        file_put_contents('data/html/' . $url, $response->getBody());
+        printf("done\n");
+    } else {
+        printf("Error on %s with HTTP status code %d\n", $url, $response->getStatusCode());
+    }
+}
+
+
+/**
+ * Returns the list of URL related to the ZF2 routes
+ *
+ * @param array $routes
+ * @return array
+ */
+function getUrlFromRoutes(array $routes) {
+    $result = [];
+    foreach($routes as $route) {
+        if (isset($route['options']['route'])) {
+            $result[] = $route['options']['route'];
+        }
+        if (isset($route['child_routes'])) {
+            $prefix = isset($route['options']['route']) ? str_replace('[/]','/', $route['options']['route']) : '';
+            $result = array_merge(
+                array_map(function ($value) use ($prefix) {
+                    return $prefix . $value;
+                }, getUrlFromRoutes($route['child_routes'])),
+                $result
+            );
+        }
+    }
+    return $result;
+}
+
+/**
+ * Filter the URLs removing optional route
+ * and omit the /application routes
+ *
+ * @param array $routes
+ * @return array
+ */
+function filterUrls(array $routes) {
+    $num    = count($routes);
+    $result = [];
+    for ($i = 0; $i < $num; $i++) {
+        if (substr($routes[$i], 0, 12) !== '/application') {
+            $result[] = str_replace('[/]', '', $routes[$i]);
+        }
+    }
+    return $result;
+}

--- a/bin/extract_advisory.php
+++ b/bin/extract_advisory.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Extract the blog posts in Markdown format
+ * ready for Jekyll
+ *
+ * @author Enrico Zimuel
+ */
+chdir(dirname(__DIR__ . '/../public'));
+include 'vendor/autoload.php';
+
+use League\HTMLToMarkdown\HtmlConverter;
+
+$folder = 'module/Security/view/security/advisory';
+$output = 'data/advisory';
+
+$converter = new HtmlConverter(array('strip_tags' => true));
+
+$config = include 'module/Security/config/module.config.php';
+
+foreach ($config['security']['advisories'] as $key => $value) {
+    printf("Extracting $key...");
+    $advisory = file_get_contents($folder . '/' . $key . '.phtml');
+    $format = <<<EOD
+---
+layout: advisory
+title: "%s"
+date: %s
+---
+
+%s
+EOD;
+
+    $content = sprintf($format,
+        str_replace('\\', '\\\\', $value['title']),
+        date("Y-m-d", strtotime($value['date'])),
+        $converter->convert($advisory)
+    );
+    file_put_contents($output . '/' . $key . '.md', $content);
+
+    printf("done\n");
+}

--- a/bin/extract_changelog.php
+++ b/bin/extract_changelog.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Extract the changelog and convert in Markdown format
+ *
+ * @author Enrico Zimuel
+ */
+chdir(dirname(__DIR__ . '/../public'));
+include 'vendor/autoload.php';
+
+use League\HTMLToMarkdown\HtmlConverter;
+
+$folder = 'data';
+$output = 'data/changelog';
+
+$converter = new HtmlConverter(array('strip_tags' => true));
+
+$zf1 = include $folder . '/zf1-changelog.php';
+$zf2 = include $folder . '/zf2-changelog.php';
+
+extractChangelog($zf1, $output);
+extractChangelog($zf2, $output);
+
+$versions = array_merge(array_keys($zf1), array_keys($zf2));
+rsort($versions, SORT_NATURAL);
+
+$content = '';
+foreach ($versions as $version) {
+  $content .= sprintf("- version : %s\n\n", $version);
+}
+file_put_contents($output . '/changelog.yml', $content);
+
+function extractChangelog(array $changelog, $output) {
+  foreach ($changelog as $id => $issues) {
+    printf("Extracting %s...", $id);
+
+    if (is_array($issues)) {
+      $content = sprintf("## Zend Framework %s\n\n", $id);
+      foreach ($issues as $issue) {
+        $content .= sprintf("- %s\t[%s](%s)\n", $issue['key'], $issue['summary'], '/issue/browse/' . $issue['key']);
+      }
+    } else {
+      $content = $issues;
+    }
+
+    if (! isset($issue['updated'])) {
+      if (! preg_match('/[0-9]{4}-[0-9]{2}-[0-9]{2}/', substr($content, 0, 256), $matches)) {
+          preg_match('/[0-9]{1,2} [A-Z]{1}[a-z]* [0-9]{4}/', substr($content, 0, 512), $matches);
+          if (isset($matches[0])) {
+            $matches[0] = date("Y-m-d", strtotime($matches[0]));
+          } else {
+            $matches[0] = '';
+          }
+      }
+      $date = $matches[0];
+    } else {
+      $date = date("Y-m-d", strtotime($issue['updated']));
+    }
+    $content = str_replace('## SECURITY', '### SECURITY', $content);
+
+    var_dump($date);
+
+    $format = <<<EOD
+---
+layout: changelog
+title: Changelog ver. %s
+date: %s
+---
+
+%s
+EOD;
+
+    $content = sprintf($format,
+        $id,
+        $date,
+        $content
+    );
+    file_put_contents($output . '/' . $id . '.md', $content);
+    printf("done.\n");
+  }
+}

--- a/bin/extract_issues.php
+++ b/bin/extract_issues.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Extract the issues in Markdown format
+ *
+ * @author Enrico Zimuel
+ */
+chdir(dirname(__DIR__ . '/../public'));
+include 'vendor/autoload.php';
+
+use League\HTMLToMarkdown\HtmlConverter;
+
+$folder = 'module/Issues/view/issues/issues';
+$output = 'data/issue';
+
+$converter = new HtmlConverter(array('strip_tags' => true));
+
+foreach (glob($folder . "/*.phtml") as $filename) {
+    printf("Extracting %s...", $filename);
+
+    $issue   = file_get_contents($filename);
+    $format = <<<EOD
+---
+layout: issue
+title: "%s"
+id: %s
+---
+
+%s
+EOD;
+
+    $id = basename($filename, '.phtml');
+
+    $issue = str_replace('{{', '', $issue);
+    $issue = str_replace('}}', '', $issue);
+
+    preg_match("/<h2>ZF[2]?\-[0-9]+\:(.*?)<\/h2>/", $issue, $matches);
+    if (isset($matches[1])) {
+      $title = trim($matches[1]);
+    } else {
+      die("ERROR!");
+    }
+    $content = sprintf($format,
+        $title,
+        $id,
+        $converter->convert($issue)
+    );
+    file_put_contents($output . '/' . $id . '.md', $content);
+
+    printf("done\n");
+}

--- a/bin/extract_posts.php
+++ b/bin/extract_posts.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Extract the blog posts in Markdown format
+ *
+ * @author Enrico Zimuel
+ */
+chdir(dirname(__DIR__ . '/../public'));
+include 'vendor/autoload.php';
+
+use League\HTMLToMarkdown\HtmlConverter;
+
+$folder = 'data/posts';
+$output = 'data/blog';
+
+$converter = new HtmlConverter(array('strip_tags' => true));
+
+foreach (glob($folder . "/*.php") as $filename) {
+    printf("Extracting %s...", $filename);
+
+    $post   = include $filename;
+    $format = <<<EOD
+---
+layout: post
+title: %s
+date: %s
+author: %s
+url_author: %s
+permalink: %s
+categories:
+- blog
+%s
+---
+
+%s
+EOD;
+
+    $categories = [ 'Apigility', 'Released', 'IRC', 'Dev', 'Expressive', 'zf3' ];
+    $category   = '';
+    foreach ($categories as $cat) {
+        if (strpos($post->getTitle(), $cat) !== false) {
+            $category .= '- ' . strtolower($cat) . "\n";
+        }
+    }
+
+    $content = sprintf($format,
+        $post->getTitle(),
+        date("Y-m-d", $post->getCreated()),
+        $post->getAuthor()->getName(),
+        $post->getAuthor()->getUrl(),
+        '/blog/' . $post->getId() . '.html',
+        $category,
+        $converter->convert($post->getBody() . $post->getExtended())
+    );
+    file_put_contents($output . '/' . $post->getId() . '.md', $content);
+
+    printf("done\n");
+}

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "phly/phly-contact": "dev-master",
         "php": ">=5.3.3",
         "zendframework/zendframework": "~2.2",
-        "zendframework/zendservice-recaptcha": "~2.0"
+        "zendframework/zendservice-recaptcha": "~2.0",
+        "league/html-to-markdown": "^4.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds some scripts in `/bin` folder to extract the following pages in Markdown format:
- advisories;
- changelog;
- issues;
- posts.

Fore the HTML to Markdown conversion I used the [league/html-to-markdown](https://github.com/thephpleague/html-to-markdown) project.